### PR TITLE
Adds Redis to the Docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,12 @@ services:
     networks:
       - crater
 
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    networks:
+      - crater
+
   nginx:
     image: nginx:1.17-alpine
     restart: unless-stopped


### PR DESCRIPTION
It's accessible with no password, on usual ports, on the `redis` host.

This would close #223 .