### PR TITLE
company.php: remove 'return ->getPath()'

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -24,11 +24,7 @@ class Company extends Model implements HasMedia
         $isSystem = FileDisk::whereSetAsDefault(true)->first()->isSystem();
 
         if ($logo) {
-            if ($isSystem) {
-                return $logo->getPath();
-            } else {
-                return $logo->getFullUrl();
-            }
+            return $logo->getFullUrl();
         }
 
         return null;


### PR DESCRIPTION
It seems not to make sense to `getPath()`, as this path is not reachable in any context from the client.

fixes https://github.com/bytefury/crater/issues/578