### PR TITLE
fix: make min item quantity 0 instead of 1

### DIFF
--- a/resources/scripts/components/estimate-invoice-common/CreateItemRow.vue
+++ b/resources/scripts/components/estimate-invoice-common/CreateItemRow.vue
@@ -53,7 +53,7 @@
                 :content-loading="loading"
                 type="number"
                 small
-                min="1"
+                min="0"
                 step="any"
                 @change="syncItemToStore()"
                 @input="v$.quantity.$touch()"
@@ -352,7 +352,7 @@ const rules = {
     required: helpers.withMessage(t('validation.required'), required),
     minValue: helpers.withMessage(
       t('validation.qty_must_greater_than_zero'),
-      minValue(1)
+      minValue(0)
     ),
     maxLength: helpers.withMessage(
       t('validation.amount_maxlength'),


### PR DESCRIPTION
Fixes #630 

Sets the minimum item quantity to >=0, rather than >=1.