### PR TITLE
Fix HTML injection vulnerability 

### DIFF
--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -157,6 +157,10 @@ trait GeneratesPdfTrait
         foreach ($customerCustomFields as $customField) {
             $fields['{'.$customField->customField->slug.'}'] = $customField->defaultAnswer;
         }
+        
+        foreach ($fields as $key => $field) {
+            $fields[$key] = htmlspecialchars($field, ENT_QUOTES, 'UTF-8');
+        }
 
         return $fields;
     }


### PR DESCRIPTION
Escape html special characters from the $fields array to prevent html injection in the generated pdfs.

Before:
![image](https://user-images.githubusercontent.com/38894210/147839521-d5c9ea0b-4317-4280-9d32-47c05a3eb39d.png)

After:
![image](https://user-images.githubusercontent.com/38894210/147839535-8479633d-fffa-43f0-ac5a-3652f19638f4.png)

Note:
This does **not** break the formatting avaliable for fields in the customisation section, allowing customisation to still be possible.
