### PR TITLE
fix: Poppins semi-bold font 404 error

### DIFF
--- a/resources/sass/crater.scss
+++ b/resources/sass/crater.scss
@@ -41,7 +41,7 @@
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url("/fonts/Poppins-Semibold.ttf") format("truetype");
+    src: url("/fonts/Poppins-SemiBold.ttf") format("truetype");
 }
 
 // Default Theme


### PR DESCRIPTION
Crater attempts to load the Poppins semi-bold font file with `Poppins-Semibold.ttf` but the file is actually `SemiBold`, so this causes a 404 error.