### PR TITLE
feat: add nginx configuration file

### DIFF
--- a/public/.nginx.conf
+++ b/public/.nginx.conf
@@ -1,0 +1,8 @@
+# Disables automated directory indexing, and redirects requests to `index.php`
+# if the direct path does not exist.
+
+autoindex off;
+
+location / {
+    try_files $uri $uri/ /index.php;
+}


### PR DESCRIPTION
We have `.htaccess` for Apache, but no equivalent for Nginx.

This PR adds an Nginx config file, which can be used through adding an `include path/to/crater/public/.nginx.conf;` line to your server config file.
