### PR TITLE
PDF download naming

### DIFF
--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -16,7 +16,7 @@ trait GeneratesPdfTrait
         if ($pdf && file_exists($pdf['path'])) {
             return response()->make(file_get_contents($pdf['path']), 200, [
                 'Content-Type' => 'application/pdf',
-                'Content-Disposition' => 'inline; filename="'.$pdf['file_name'].'.pdf"',
+                'Content-Disposition' => 'inline; filename="'.$pdf['file_name'].'"',
             ]);
         }
 


### PR DESCRIPTION
Fixes #773 


To reproduce the issue, company setting **save_pdf_to_disk** should be set  to **YES**. 