### PR TITLE
Arrange Invoice, Recurring Invoices and Estimate Tab groups for a more natural flow

### DIFF
--- a/resources/scripts/admin/views/estimates/Index.vue
+++ b/resources/scripts/admin/views/estimates/Index.vue
@@ -134,9 +134,9 @@
       >
         <!-- Tabs -->
         <BaseTabGroup class="-mb-5" @change="setStatusFilter">
+          <BaseTab :title="$t('general.all')" filter="" />
           <BaseTab :title="$t('general.draft')" filter="DRAFT" />
           <BaseTab :title="$t('general.sent')" filter="SENT" />
-          <BaseTab :title="$t('general.all')" filter="" />
         </BaseTabGroup>
 
         <BaseDropdown

--- a/resources/scripts/admin/views/invoices/Index.vue
+++ b/resources/scripts/admin/views/invoices/Index.vue
@@ -131,10 +131,10 @@
       >
         <!-- Tabs -->
         <BaseTabGroup class="-mb-5" @change="setStatusFilter">
-          <BaseTab :title="$t('general.draft')" filter="DRAFT" />
-          <BaseTab :title="$t('general.due')" filter="DUE" />
-          <BaseTab :title="$t('general.sent')" filter="SENT" />
           <BaseTab :title="$t('general.all')" filter="" />
+          <BaseTab :title="$t('general.draft')" filter="DRAFT" />
+          <BaseTab :title="$t('general.sent')" filter="SENT" />
+          <BaseTab :title="$t('general.due')" filter="DUE" />
         </BaseTabGroup>
 
         <BaseDropdown

--- a/resources/scripts/admin/views/recurring-invoices/Index.vue
+++ b/resources/scripts/admin/views/recurring-invoices/Index.vue
@@ -129,9 +129,9 @@
           :default-index="currentStatusIndex"
           @change="setStatusFilter"
         >
+          <BaseTab :title="$t('recurring_invoices.all')" filter="ALL" />
           <BaseTab :title="$t('recurring_invoices.active')" filter="ACTIVE" />
           <BaseTab :title="$t('recurring_invoices.on_hold')" filter="ON_HOLD" />
-          <BaseTab :title="$t('recurring_invoices.all')" filter="ALL" />
         </BaseTabGroup>
 
         <BaseDropdown


### PR DESCRIPTION
The proposal here is to arrange the Estimates, Invoices and Recurring Invoices index page to display the tab group filters in a more natural flow. As a user, you would expect that when you select either of these items you're presented with a list of all of them, then you can willing filter down by their status i.e. Due, Sent, Draft.

I'll also work on creating a PR to the Crater mobile repo so that the user experience stays consitent across the use of Crater applications.﻿

![image](https://user-images.githubusercontent.com/39342367/154783522-a1830f51-0110-446c-b916-98b9ed5a74d4.png)
![image](https://user-images.githubusercontent.com/39342367/154783535-96609f99-d453-45be-bb23-ab1002c45d5d.png)
