### PR TITLE
fix: use `$is_args` rather than hardcoded `?` in nginx config

### DIFF
--- a/docker-compose/nginx/nginx.conf
+++ b/docker-compose/nginx/nginx.conf
@@ -16,7 +16,7 @@ server {
         fastcgi_read_timeout 300;
     }
     location / {
-        try_files $uri $uri/ /index.php?$query_string;
+        try_files $uri $uri/ /index.php$is_args$query_string;
         gzip_static on;
     }
 }


### PR DESCRIPTION
See: https://nginx.org/en/docs/http/ngx_http_core_module.html#var_is_args

This prevents requests with no query strings being passed to Fast CGI as `https://example.com?` as opposed to `https://example.com`.