### PR TITLE
add default support for Central African currency

### DIFF
--- a/database/seeders/CurrenciesTableSeeder.php
+++ b/database/seeders/CurrenciesTableSeeder.php
@@ -276,6 +276,14 @@ class CurrenciesTableSeeder extends Seeder
                 'decimal_separator' => ',',
             ],
             [
+                'name' => 'Central African Franc',
+                'code' => 'XAF',
+                'symbol' => 'CFA ',
+                'precision' => '2',
+                'thousand_separator' => ',',
+                'decimal_separator' => '.',
+            ],
+            [
                 'name' => 'West African Franc',
                 'code' => 'XOF',
                 'symbol' => 'CFA ',


### PR DESCRIPTION
As a central African resident (precisely in Cameroon), the default support of the XAF currency is needed. 