### PR TITLE
Update company logo and alternate text

### DIFF
--- a/app/Http/Controllers/V1/Admin/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/V1/Admin/Dashboard/DashboardController.php
@@ -104,6 +104,7 @@ class DashboardController extends Controller
             'invoice_date',
             [$startDate->format('Y-m-d'), $start->format('Y-m-d')]
         )
+            ->where('status', '<>', 'DRAFT')
             ->whereCompany()
             ->sum('base_total');
 
@@ -133,17 +134,21 @@ class DashboardController extends Controller
 
         $total_customer_count = Customer::whereCompany()->count();
         $total_invoice_count = Invoice::whereCompany()
+            ->where('status', '<>', 'DRAFT')
             ->count();
         $total_estimate_count = Estimate::whereCompany()->count();
         $total_amount_due = Invoice::whereCompany()
+            ->where('status', '<>', 'DRAFT')
             ->sum('base_due_amount');
 
         $recent_due_invoices = Invoice::with('customer')
             ->whereCompany()
             ->where('base_due_amount', '>', 0)
+            ->where('status', '<>', 'DRAFT')
             ->take(5)
             ->latest()
             ->get();
+
         $recent_estimates = Estimate::with('customer')->whereCompany()->take(5)->latest()->get();
 
         return response()->json([

--- a/resources/views/app/pdf/estimate/estimate1.blade.php
+++ b/resources/views/app/pdf/estimate/estimate1.blade.php
@@ -393,11 +393,11 @@
         <table width="100%">
             <tr>
                 <td class="text-center">
-                    @if ($logo)
-                        <img class="header-logo" style="height: 50px;" src="{{ $logo }}" alt="Company Logo">
+                    @if ($estimate->customer->company->logo)
+                        <img class="header-logo" style="height: 50px;" src="{{ $estimate->customer->company->logo }}" alt="{{$estimate->customer->company->name}}" />
                     @else
                         @if ($estimate->customer->company)
-                            <h2 class="header-logo"> {{ $estimate->customer->company->name }} </h2>
+                            <h2 class="header-logo">{{ $estimate->customer->company->name }}</h2>
                         @endif
                     @endif
                 </td>

--- a/resources/views/app/pdf/estimate/estimate2.blade.php
+++ b/resources/views/app/pdf/estimate/estimate2.blade.php
@@ -414,14 +414,14 @@
     <div class="header-container">
         <table width="100%">
             <tr>
-                @if ($logo)
+                @if ($estimate->customer->company->logo)
                     <td width="60%" class="header-section-left">
-                        <img class="header-logo" style="height: 50px;" src="{{ $logo }}" alt="Company Logo">
+                        <img class="header-logo" style="height: 50px;" src="{{ $estimate->customer->company->logo }}" alt="{{$estimate->customer->company->name}}" />
                     </td>
                 @else
                     <td width="60%" class="header-section-left" style="padding-top: 0px;">
                         @if ($estimate->customer->company)
-                            <h1 class="header-logo"> {{ $estimate->customer->company->name }} </h1>
+                            <h1 class="header-logo">{{ $estimate->customer->company->name }}</h1>
                         @endif
                     </td>
                 @endif

--- a/resources/views/app/pdf/estimate/estimate3.blade.php
+++ b/resources/views/app/pdf/estimate/estimate3.blade.php
@@ -353,10 +353,10 @@
         <table width="100%">
             <tr>
                 <td width="50%" class="header-section-left">
-                    @if ($logo)
-                        <img class="header-logo" style="height: 50px;" src="{{ $logo }}" alt="Company Logo">
+                    @if ($estimate->customer->company->logo)
+                        <img class="header-logo" style="height: 50px;" src="{{ $estimate->customer->company->logo }}" alt="{{$estimate->customer->company->name}}" />
                     @else
-                        <h1 class="header-logo"> {{ $estimate->customer->company->name }} </h1>
+                        <h1 class="header-logo">{{ $estimate->customer->company->name }}</h1>
                     @endif
                 </td>
                 <td width="50%" class="text-right company-address-container company-address">

--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -334,11 +334,11 @@
         <table width="100%">
             <tr>
                 <td class="text-center">
-                    @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ $logo }}" alt="Company Logo">
+                    @if ($invoice->customer->company->logo)
+                        <img class="header-logo" style="height:50px" src="{{ $invoice->customer->company->logo }}" alt="{{ $invoice->customer->company->name }}" />
                     @else
                         @if ($invoice->customer->company)
-                            <h2 class="header-logo"> {{ $invoice->customer->company->name }}</h2>
+                            <h2 class="header-logo">{{ $invoice->customer->company->name }}</h2>
                         @endif
                     @endif
                 </td>

--- a/resources/views/app/pdf/invoice/invoice2.blade.php
+++ b/resources/views/app/pdf/invoice/invoice2.blade.php
@@ -384,12 +384,10 @@
         <table width="100%">
             <tr>
                 <td width="60%" class="header-section-left">
-                    @if ($logo)
-                        <img class="header-logo" src="{{ $logo }}" alt="Company Logo" style="height: 50px;">
+                    @if ($invoice->customer->company->logo)
+                        <img class="header-logo" style="height: 50px;" src="{{ $invoice->customer->company->logo }}" alt="{{$invoice->customer->company->name}}" />
                     @elseif ($invoice->customer->company)
-                        <h1 class="header-logo" style="padding-top: 0px;">
-                            {{ $invoice->customer->company->name }}
-                        </h1>
+                        <h1 class="header-logo" style="padding-top: 0px;">{{ $invoice->customer->company->name }}</h1>
                     @endif
                 </td>
 

--- a/resources/views/app/pdf/invoice/invoice3.blade.php
+++ b/resources/views/app/pdf/invoice/invoice3.blade.php
@@ -312,10 +312,10 @@
         <table width="100%">
             <tr>
                 <td width="50%" class="header-section-left">
-                    @if($logo)
-                    <img class="header-logo" style="height: 50px;" src="{{ $logo }}" alt="Company Logo">
+                    @if($invoice->customer->company->logo)
+                        <img class="header-logo" style="height: 50px;" src="{{ $invoice->customer->company->logo }}" alt="{{ $invoice->customer->company->name }}" />
                     @else
-                    <h1 class="header-logo"> {{$invoice->customer->company->name}} </h1>
+                        <h1 class="header-logo">{{$invoice->customer->company->name}}</h1>
                     @endif
                 </td>
                 <td width="50%" class="text-right company-address-container company-address">

--- a/resources/views/app/pdf/payment/payment.blade.php
+++ b/resources/views/app/pdf/payment/payment.blade.php
@@ -282,14 +282,14 @@
     <div class="header-container">
         <table width="100%">
             <tr>
-                @if ($logo)
+                @if ($payment->customer->company->logo)
                     <td width="50%" class="header-section-left">
-                        <img style="height: 50px;" class="header-logo" src="{{ $logo }}" alt="Company Logo">
-                    @else
-                        @if ($payment->customer)
+                        <img class="header-logo" style="height: 50px;" src="{{ $payment->customer->company->logo }}" alt="{{$payment->customer->company->name}}" />
+                @else
+                    @if ($payment->customer)
                     <td class="header-section-left" style="padding-top:0px;">
-                        <h1 class="header-logo"> {{ $payment->customer->company->name }} </h1>
-                @endif
+                        <h1 class="header-logo">{{ $payment->customer->company->name }}</h1>
+                    @endif
                 @endif
                 </td>
                 <td width="50%" class="header-section-right company-details company-address">


### PR DESCRIPTION
While investigating an issue with the HTML preview of invoices (which is used by the mobile app), I discovered that the wrong parameter was being used to set the company logo.  The $logo parameter contained the local file path and not a URL-compatible path.

At the same time, all invoice templates were updated to have consistent code formatting and the placeholder alternate text of "Company Logo" was replaced with the company name parameter.