### PR TITLE
Make all data on docker-compose persistent by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
     restart: always
     volumes:
       - db:/var/lib/mysql
-      # If you want to persist data on the host, comment the line above this one...
-      # and uncomment the line under this one.
-      #- ./docker-compose/db/data:/var/lib/mysql:rw,delegated
+      # - db:/var/lib/mysql
+      # If you are running in a development environment and don't want the DB data to persist uncomment the line above and comment the line below
+      - ./docker-compose/db/data:/var/lib/mysql:rw,delegated
     environment:
       MYSQL_USER: crater
       MYSQL_PASSWORD: crater


### PR DESCRIPTION
There is a potential for users who never used docker before and rely on developer's documentation to lose data if they are running docker in production.

The default behaviour does not make data persistent meaning if docker container restarts or machine loses power all data is gone. I've changed the default behaviour to be the opposite and to only make data volatile if the person is using docker in development environment.