### PR TITLE
[WiP] Add item categories

### DIFF
--- a/app/Http/Controllers/V1/Admin/Item/ItemCategoriesController.php
+++ b/app/Http/Controllers/V1/Admin/Item/ItemCategoriesController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Crater\Http\Controllers\V1\Admin\Item;
+
+use Crater\Http\Controllers\Controller;
+use Crater\Http\Requests\ItemCategoryRequest;
+use Crater\Http\Resources\ItemCategoryResource;
+use Crater\Models\ItemCategory;
+use Illuminate\Http\Request;
+
+class ItemCategoriesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $this->authorize('viewAny', ItemCategory::class);
+
+        $limit = $request->has('limit') ? $request->limit : 5;
+
+        $categories = ItemCategory::applyFilters($request->all())
+            ->whereCompany()
+            ->latest()
+            ->paginateData($limit);
+
+        return ItemCategoryResource::collection($categories);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return ItemCategoryResource
+     */
+    public function store(ItemCategoryRequest $request)
+    {
+        $this->authorize('create', ItemCategory::class);
+
+        $category = ItemCategory::create($request->getItemCategoryPayload());
+
+        return new ItemCategoryResource($category);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \Crater\Models\ItemCategory $category
+     * @return ItemCategoryResource
+     */
+    public function show(ItemCategory $category)
+    {
+        $this->authorize('view', $category);
+
+        return new ItemCategoryResource($category);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Crater\Models\ItemCategory $ItemCategory
+     * @return ItemCategoryResource
+     */
+    public function update(ItemCategoryRequest $request, ItemCategory $category)
+    {
+        $this->authorize('update', $category);
+
+        $category->update($request->getItemCategoryPayload());
+
+        return new ItemCategoryResource($category);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \Crater\Models\ItemCategory $category
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(ItemCategory $category)
+    {
+        $this->authorize('delete', $category);
+
+        if ($category->items() && $category->items()->count() > 0) {
+            return respondJson('item_attached', 'Item Attached');
+        }
+
+        $category->delete();
+
+        return response()->json([
+            'success' => true,
+        ]);
+    }
+}

--- a/app/Http/Requests/ItemCategoryRequest.php
+++ b/app/Http/Requests/ItemCategoryRequest.php
@@ -29,7 +29,8 @@ class ItemCategoryRequest extends FormRequest
             ],
             'number' => [
                 'required',
-                'integer'
+                'integer',
+                'min:1'
             ],
         ];
     }

--- a/app/Http/Requests/ItemCategoryRequest.php
+++ b/app/Http/Requests/ItemCategoryRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Crater\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ItemCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'required',
+            ],
+            'number' => [
+                'required',
+                'integer'
+            ],
+        ];
+    }
+
+    public function getItemCategoryPayload()
+    {
+        return collect($this->validated())
+            ->merge([
+                'company_id' => $this->header('company')
+            ])
+            ->toArray();
+    }
+}

--- a/app/Http/Resources/ItemCategoryCollection.php
+++ b/app/Http/Resources/ItemCategoryCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Crater\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ItemCategoryCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/ItemCategoryResource.php
+++ b/app/Http/Resources/ItemCategoryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Crater\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ItemCategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'number' => $this->number,
+            'company_id' => $this->company_id,
+            'formatted_created_at' => $this->formattedCreatedAt,
+            'company' => $this->when($this->company()->exists(), function () {
+                return new CompanyResource($this->company);
+            }),
+        ];
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -41,6 +41,11 @@ class Item extends Model
         return $this->belongsTo(Currency::class);
     }
 
+    public function category()
+    {
+        return $this->belongsTo(ItemCategory::class, 'item_category_id');
+    }
+
     public function scopeWhereSearch($query, $search)
     {
         return $query->where('items.name', 'LIKE', '%'.$search.'%');
@@ -80,6 +85,10 @@ class Item extends Model
 
         if ($filters->get('unit_id')) {
             $query->whereUnit($filters->get('unit_id'));
+        }
+
+        if ($filters->get('item_category_id')) {
+            $query->whereCategory($filters->get('item_category_id'));
         }
 
         if ($filters->get('item_id')) {

--- a/app/Models/ItemCategory.php
+++ b/app/Models/ItemCategory.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Crater\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ItemCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'number', 'company_id'];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = ['formattedCreatedAt'];
+
+    public function items()
+    {
+        return $this->hasMany(Item::class);
+    }
+
+    public function company()
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function getFormattedCreatedAtAttribute($value)
+    {
+        $dateFormat = CompanySetting::getSetting('carbon_date_format', $this->company_id);
+
+        return Carbon::parse($this->created_at)->format($dateFormat);
+    }
+
+    public function scopeWhereCompany($query)
+    {
+        $query->where('company_id', request()->header('company'));
+    }
+
+    public function scopeWhereCategory($query, $category_id)
+    {
+        $query->orWhere('id', $category_id);
+    }
+
+    public function scopeWhereSearch($query, $search)
+    {
+        $query->where('name', 'LIKE', '%'.$search.'%');
+    }
+
+    public function scopeApplyFilters($query, array $filters)
+    {
+        $filters = collect($filters);
+
+        if ($filters->get('category_id')) {
+            $query->whereCategory($filters->get('category_id'));
+        }
+
+        if ($filters->get('company_id')) {
+            $query->whereCompany($filters->get('company_id'));
+        }
+
+        if ($filters->get('search')) {
+            $query->whereSearch($filters->get('search'));
+        }
+    }
+
+    public function scopePaginateData($query, $limit)
+    {
+        if ($limit == 'all') {
+            return $query->get();
+        }
+
+        return $query->paginate($limit);
+    }
+}

--- a/app/Policies/ItemCategoryPolicy.php
+++ b/app/Policies/ItemCategoryPolicy.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Crater\Policies;
+
+use Crater\Models\ItemCategory;
+use Crater\Models\Item;
+use Crater\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Silber\Bouncer\BouncerFacade;
+
+class ItemCategoryPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \Crater\Models\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        if (BouncerFacade::can('view-item', Item::class)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \Crater\Models\User  $user
+     * @param  \Crater\Models\ItemCategory  $itemCategory
+     * @return mixed
+     */
+    public function view(User $user, ItemCategory $itemCategory)
+    {
+        if (BouncerFacade::can('view-item', Item::class) && $user->hasCompany($itemCategory->company_id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \Crater\Models\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        if (BouncerFacade::can('view-item', Item::class)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \Crater\Models\User  $user
+     * @param  \Crater\Models\ItemCategory  $itemCategory
+     * @return mixed
+     */
+    public function update(User $user, ItemCategory $itemCategory)
+    {
+        if (BouncerFacade::can('view-item', Item::class) && $user->hasCompany($itemCategory->company_id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \Crater\Models\User  $user
+     * @param  \Crater\Models\ItemCategory  $itemCategory
+     * @return mixed
+     */
+    public function delete(User $user, ItemCategory $itemCategory)
+    {
+        if (BouncerFacade::can('view-item', Item::class) && $user->hasCompany($itemCategory->company_id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \Crater\Models\User  $user
+     * @param  \Crater\Models\ItemCategory  $itemCategory
+     * @return mixed
+     */
+    public function restore(User $user, ItemCategory $itemCategory)
+    {
+        if (BouncerFacade::can('view-item', Item::class) && $user->hasCompany($itemCategory->company_id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \Crater\Models\User  $user
+     * @param  \Crater\Models\ItemCategory  $itemCategory
+     * @return mixed
+     */
+    public function forceDelete(User $user, ItemCategory $itemCategory)
+    {
+        if (BouncerFacade::can('view-item', Item::class) && $user->hasCompany($itemCategory->company_id)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/config/crater.php
+++ b/config/crater.php
@@ -226,6 +226,16 @@ return [
             'model' => Note::class
         ],
         [
+            'title' => 'settings.menu_title.item_category',
+            'group' => '',
+            'name' => 'Item Category',
+            'link' => '/admin/settings/item-category',
+            'icon' => 'ClipboardListIcon',
+            'owner_only' => false,
+            'ability' => 'view-item',
+            'model' => Item::class
+        ],
+        [
             'title' => 'settings.menu_title.expense_category',
             'group' => '',
             'name' => 'Expense Category',

--- a/database/factories/ItemCategoryFactory.php
+++ b/database/factories/ItemCategoryFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Crater\Models\ItemCategory;
+use Crater\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ItemCategoryFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ItemCategory::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word,
+            'number' => $this->faker->randomNumber(3),
+            'company_id' => User::find(1)->companies()->first()->id,
+        ];
+    }
+}

--- a/database/migrations/2022_07_22_223642_create_item_categories_table.php
+++ b/database/migrations/2022_07_22_223642_create_item_categories_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateItemCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('item_categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('number')->unsigned();
+            $table->integer('company_id')->unsigned()->nullable();
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('item_categories');
+    }
+}

--- a/database/migrations/2022_07_24_201516_add_category_to_items.php
+++ b/database/migrations/2022_07_24_201516_add_category_to_items.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCategoryToItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->integer('item_category_id')->unsigned()->nullable();
+            $table->foreign('item_category_id')->references('id')->on('item_categories')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropColumn('item_category_id');
+            $table->dropForeign('item_category_id');
+        });
+    }
+}

--- a/resources/scripts/admin/admin-router.js
+++ b/resources/scripts/admin/admin-router.js
@@ -43,6 +43,8 @@ const CustomFieldsIndex = () =>
   import('@/scripts/admin/views/settings/CustomFieldsSetting.vue')
 const NotesSetting = () =>
   import('@/scripts/admin/views/settings/NotesSetting.vue')
+const ItemCategory = () =>
+  import('@/scripts/admin/views/settings/ItemCategorySetting.vue')
 const ExpenseCategory = () =>
   import('@/scripts/admin/views/settings/ExpenseCategorySetting.vue')
 const ExchangeRateSetting = () =>
@@ -295,6 +297,12 @@ export default [
             name: 'custom.fields',
             meta: { ability: abilities.VIEW_CUSTOM_FIELDS },
             component: CustomFieldsIndex,
+          },
+          {
+            path: 'item-category',
+            name: 'item.category',
+            meta: { ability: abilities.VIEW_ITEM },
+            component: ItemCategory,
           },
           {
             path: 'expense-category',

--- a/resources/scripts/admin/components/dropdowns/ItemCategoryIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/ItemCategoryIndexDropdown.vue
@@ -76,7 +76,7 @@ function editItemCategory(data) {
   itemCategoryStore.fetchCategory(data)
   modalStore.openModal({
     title: t('settings.item_category.edit_category'),
-    componentName: 'CategoryModal',
+    componentName: 'ItemCategoryModal',
     refreshData: props.loadData,
     size: 'sm',
   })

--- a/resources/scripts/admin/components/dropdowns/ItemCategoryIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/ItemCategoryIndexDropdown.vue
@@ -1,0 +1,105 @@
+<template>
+  <BaseDropdown>
+    <template #activator>
+      <BaseButton
+        v-if="route.name === 'ItemCategories.view'"
+        variant="primary"
+      >
+        <BaseIcon name="DotsHorizontalIcon" class="h-5 text-white" />
+      </BaseButton>
+      <BaseIcon v-else name="DotsHorizontalIcon" class="h-5 text-gray-500" />
+    </template>
+
+    <!-- edit itemCategory  -->
+    <BaseDropdownItem
+      v-if="userStore.hasAbilities(abilities.EDIT_ITEM)"
+      @click="editItemCategory(row.id)"
+    >
+      <BaseIcon
+        name="PencilIcon"
+        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+      />
+      {{ $t('general.edit') }}
+    </BaseDropdownItem>
+
+    <!-- delete itemCategory  -->
+    <BaseDropdownItem
+      v-if="userStore.hasAbilities(abilities.DELETE_ITEM)"
+      @click="removeItemCategory(row.id)"
+    >
+      <BaseIcon
+        name="TrashIcon"
+        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+      />
+      {{ $t('general.delete') }}
+    </BaseDropdownItem>
+  </BaseDropdown>
+</template>
+
+<script setup>
+import { useDialogStore } from '@/scripts/stores/dialog'
+import { useNotificationStore } from '@/scripts/stores/notification'
+import { useI18n } from 'vue-i18n'
+import { useItemCategoryStore } from '@/scripts/admin/stores/item-category'
+import { useRoute, useRouter } from 'vue-router'
+import { inject } from 'vue'
+import { useUserStore } from '@/scripts/admin/stores/user'
+import { useModalStore } from '@/scripts/stores/modal'
+import abilities from '@/scripts/admin/stub/abilities'
+
+const props = defineProps({
+  row: {
+    type: Object,
+    default: null,
+  },
+  table: {
+    type: Object,
+    default: null,
+  },
+  loadData: {
+    type: Function,
+    default: null,
+  },
+})
+
+const dialogStore = useDialogStore()
+const notificationStore = useNotificationStore()
+const { t } = useI18n()
+const itemCategoryStore = useItemCategoryStore()
+const route = useRoute()
+const userStore = useUserStore()
+const modalStore = useModalStore()
+
+const $utils = inject('utils')
+
+function editItemCategory(data) {
+  itemCategoryStore.fetchCategory(data)
+  modalStore.openModal({
+    title: t('settings.item_category.edit_category'),
+    componentName: 'CategoryModal',
+    refreshData: props.loadData,
+    size: 'sm',
+  })
+}
+
+function removeItemCategory(id) {
+  dialogStore
+    .openDialog({
+      title: t('general.are_you_sure'),
+      message: t('settings.item_category.confirm_delete'),
+      yesLabel: t('general.ok'),
+      noLabel: t('general.cancel'),
+      variant: 'danger',
+      hideNoButton: false,
+      size: 'lg',
+    })
+    .then(async () => {
+      let response = await itemCategoryStore.deleteCategory(id)
+      if (response.data.success) {
+        props.loadData && props.loadData()
+        return true
+      }
+      props.loadData && props.loadData()
+    })
+}
+</script>

--- a/resources/scripts/admin/components/modal-components/ItemCategoryModal.vue
+++ b/resources/scripts/admin/components/modal-components/ItemCategoryModal.vue
@@ -1,0 +1,167 @@
+<template>
+  <BaseModal :show="modalActive" @close="closeCategoryModal">
+    <template #header>
+      <div class="flex justify-between w-full">
+        {{ modalStore.title }}
+        <BaseIcon
+          name="XIcon"
+          class="w-6 h-6 text-gray-500 cursor-pointer"
+          @click="closeCategoryModal"
+        />
+      </div>
+    </template>
+
+    <form action="" @submit.prevent="submitCategoryData">
+      <div class="p-8 sm:p-6">
+        <BaseInputGrid layout="one-column">
+          <BaseInputGroup
+            :label="$t('settings.item_category.category_name')"
+            :error="
+              v$.currentCategory.name.$error &&
+              v$.currentCategory.name.$errors[0].$message
+            "
+            required
+          >
+            <BaseInput
+              v-model="categoryStore.currentCategory.name"
+              :invalid="v$.currentCategory.name.$error"
+              type="text"
+              @input="v$.currentCategory.name.$touch()"
+            />
+          </BaseInputGroup>
+
+          <BaseInputGroup
+            :label="$t('settings.item_category.category_number')"
+            :error="
+              v$.currentCategory.number.$error &&
+              v$.currentCategory.number.$errors[0].$message
+            "
+            required
+          >
+            <BaseInput
+              v-model="categoryStore.currentCategory.number"
+              type="number"
+              @input="v$.currentCategory.number.$touch()"
+            />
+          </BaseInputGroup>
+        </BaseInputGrid>
+      </div>
+
+      <div
+        class="
+          z-0
+          flex
+          justify-end
+          p-4
+          border-t border-gray-200 border-solid border-modal-bg
+        "
+      >
+        <BaseButton
+          type="button"
+          variant="primary-outline"
+          class="mr-3 text-sm"
+          @click="closeCategoryModal"
+        >
+          {{ $t('general.cancel') }}
+        </BaseButton>
+
+        <BaseButton
+          :loading="isSaving"
+          :disabled="isSaving"
+          variant="primary"
+          type="submit"
+        >
+          <template #left="slotProps">
+            <BaseIcon
+              v-if="!isSaving"
+              name="SaveIcon"
+              :class="slotProps.class"
+            />
+          </template>
+          {{ categoryStore.isEdit ? $t('general.update') : $t('general.save') }}
+        </BaseButton>
+      </div>
+    </form>
+  </BaseModal>
+</template>
+
+<script setup>
+import { useItemCategoryStore } from "@/scripts/admin/stores/item-category";
+import { useModalStore } from '@/scripts/stores/modal'
+import { computed, ref } from 'vue'
+import { required, minLength, integer, minValue, helpers } from '@vuelidate/validators'
+import { useVuelidate } from '@vuelidate/core'
+import { useI18n } from 'vue-i18n'
+import BaseInput from "@/scripts/components/base/BaseInput.vue";
+
+const categoryStore = useItemCategoryStore()
+const modalStore = useModalStore()
+const { t } = useI18n()
+
+let isSaving = ref(false)
+
+const rules = computed(() => {
+  return {
+    currentCategory: {
+      name: {
+        required: helpers.withMessage(t('validation.required'), required),
+        minLength: helpers.withMessage(
+          t('validation.name_min_length', { count: 3 }),
+          minLength(3)
+        ),
+      },
+      number: {
+        required: helpers.withMessage(t('validation.required'), required),
+        integer: helpers.withMessage(
+          t('validation.description_integer'),
+          integer
+        ),
+        minValueValue: helpers.withMessage(
+          t('validation.name_min_value', { amount: 0 }),
+          minValue(0)
+        ),
+      },
+    },
+  }
+})
+
+const v$ = useVuelidate(
+  rules,
+  computed(() => categoryStore)
+)
+
+const modalActive = computed(() => {
+  return modalStore.active && modalStore.componentName === 'ItemCategoryModal'
+})
+
+async function submitCategoryData() {
+  v$.value.currentCategory.$touch()
+
+  if (v$.value.currentCategory.$invalid) {
+    return true
+  }
+
+  const action = categoryStore.isEdit
+    ? categoryStore.updateCategory
+    : categoryStore.addCategory
+
+  isSaving.value = true
+
+  await action(categoryStore.currentCategory)
+
+  isSaving.value = false
+
+  modalStore.refreshData ? modalStore.refreshData() : ''
+
+  closeCategoryModal()
+}
+
+function closeCategoryModal() {
+  modalStore.closeModal()
+
+  setTimeout(() => {
+    categoryStore.$reset()
+    v$.value.$reset()
+  }, 300)
+}
+</script>

--- a/resources/scripts/admin/stores/item-category.js
+++ b/resources/scripts/admin/stores/item-category.js
@@ -1,0 +1,129 @@
+import axios from 'axios'
+import { defineStore } from 'pinia'
+import { useNotificationStore } from '@/scripts/stores/notification'
+import { handleError } from '@/scripts/helpers/error-handling'
+
+export const useItemCategoryStore = (useWindow = false) => {
+  const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
+  const { global } = window.i18n
+
+  return defineStoreFunc({
+    id: 'item-category',
+
+    state: () => ({
+      categories: [],
+      currentCategory: {
+        id: null,
+        name: '',
+        number: '',
+      },
+      editCategory: null
+    }),
+
+    getters: {
+      isEdit: (state) => (state.currentCategory.id ? true : false),
+    },
+
+    actions: {
+      fetchCategories(params) {
+        return new Promise((resolve, reject) => {
+          axios
+            .get(`/api/v1/items/categories`, { params })
+            .then((response) => {
+              this.categories = response.data.data
+              resolve(response)
+            })
+            .catch((err) => {
+              handleError(err)
+              reject(err)
+            })
+        })
+      },
+
+      fetchCategory(id) {
+        return new Promise((resolve, reject) => {
+          axios
+            .get(`/api/v1/items/categories/${id}`)
+            .then((response) => {
+              this.currentCategory = response.data.data
+              resolve(response)
+            })
+            .catch((err) => {
+              handleError(err)
+              reject(err)
+            })
+        })
+      },
+
+      addCategory(data) {
+        return new Promise((resolve, reject) => {
+          axios
+            .post('/api/v1/items/categories', data)
+            .then((response) => {
+              this.categories.push(response.data.data)
+              const notificationStore = useNotificationStore()
+              notificationStore.showNotification({
+                type: 'success',
+                message: global.t('settings.item_category.created_message'),
+              })
+              resolve(response)
+            })
+            .catch((err) => {
+              handleError(err)
+              reject(err)
+            })
+        })
+      },
+
+      updateCategory(data) {
+        return new Promise((resolve, reject) => {
+          axios
+            .put(`/api/v1/items/categories/${data.id}`, data)
+            .then((response) => {
+              if (response.data) {
+                let pos = this.categories.findIndex(
+                  (category) => category.id === response.data.data.id
+                )
+                this.categories[pos] = data.categories
+                const notificationStore = useNotificationStore()
+                notificationStore.showNotification({
+                  type: 'success',
+                  message: global.t(
+                    'settings.items_category.updated_message'
+                  ),
+                })
+              }
+              resolve(response)
+            })
+            .catch((err) => {
+              handleError(err)
+              reject(err)
+            })
+        })
+      },
+
+      deleteCategory(id) {
+        return new Promise((resolve) => {
+          axios
+            .delete(`/api/v1/items/categories/${id}`)
+            .then((response) => {
+              let index = this.categories.findIndex(
+                (category) => category.id === id
+              )
+              this.categories.splice(index, 1)
+              const notificationStore = useNotificationStore()
+              notificationStore.showNotification({
+                type: 'success',
+                message: global.t('settings.item_category.deleted_message'),
+              })
+              resolve(response)
+            })
+            .catch((err) => {
+              handleError(err)
+              console.error(err)
+            })
+        })
+      },
+    },
+  })()
+}

--- a/resources/scripts/admin/views/settings/ItemCategorySetting.vue
+++ b/resources/scripts/admin/views/settings/ItemCategorySetting.vue
@@ -1,0 +1,117 @@
+<template>
+  <ItemCategoryModal />
+
+  <BaseSettingCard
+    :title="$t('settings.item_category.title')"
+    :description="$t('settings.item_category.description')"
+  >
+    <template #action>
+      <BaseButton
+        variant="primary-outline"
+        type="button"
+        @click="openCategoryModal"
+      >
+        <template #left="slotProps">
+          <BaseIcon :class="slotProps.class" name="PlusIcon" />
+        </template>
+
+        {{ $t('settings.item_category.add_new_category') }}
+      </BaseButton>
+    </template>
+
+    <BaseTable
+      ref="table"
+      :data="fetchData"
+      :columns="ItemCategoryColumns"
+      class="mt-16"
+    >
+      <template #cell-description="{ row }">
+        <div class="w-64">
+          <p class="truncate">{{ row.data.number }}</p>
+        </div>
+      </template>
+
+      <template #cell-actions="{ row }">
+        <ItemCategoryIndexDropdown
+          :row="row.data"
+          :table="table"
+          :load-data="refreshTable"
+        />
+      </template>
+    </BaseTable>
+  </BaseSettingCard>
+</template>
+
+<script setup>
+import { useDialogStore } from '@/scripts/stores/dialog'
+import { useItemCategoryStore } from '@/scripts/admin/stores/item-category'
+import { useModalStore } from '@/scripts/stores/modal'
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ItemCategoryIndexDropdown from '@/scripts/admin/components/dropdowns/ItemCategoryIndexDropdown.vue'
+import ItemCategoryModal from '@/scripts/admin/components/modal-components/ItemCategoryModal.vue'
+
+const categoryStore = useItemCategoryStore()
+const dialogStore = useDialogStore()
+const modalStore = useModalStore()
+
+const { t } = useI18n()
+
+const table = ref(null)
+
+const ItemCategoryColumns = computed(() => {
+  return [
+    {
+      key: 'name',
+      label: t('settings.item_category.category_name'),
+      thClass: 'extra',
+      tdClass: 'font-medium text-gray-900',
+    },
+    {
+      key: 'number',
+      label: t('settings.item_category.category_number'),
+      thClass: 'extra',
+      tdClass: 'font-medium text-gray-900',
+    },
+
+    {
+      key: 'actions',
+      label: '',
+      tdClass: 'text-right text-sm font-medium',
+      sortable: false,
+    },
+  ]
+})
+
+async function fetchData({ page, filter, sort }) {
+  let data = {
+    orderByField: sort.fieldName || 'number',
+    orderBy: sort.order || 'asc',
+    page,
+  }
+
+  let response = await categoryStore.fetchCategories(data)
+  return {
+    data: response.data.data,
+    pagination: {
+      totalPages: response.data.meta.last_page,
+      currentPage: page,
+      totalCount: response.data.meta.total,
+      limit: 5,
+    },
+  }
+}
+
+function openCategoryModal() {
+  modalStore.openModal({
+    title: t('settings.item_category.add_category'),
+    componentName: 'ItemCategoryModal',
+    size: 'sm',
+    refreshData: table.value && table.value.refresh,
+  })
+}
+
+async function refreshTable() {
+  table.value && table.value.refresh()
+}
+</script>

--- a/resources/scripts/locales/de.json
+++ b/resources/scripts/locales/de.json
@@ -799,6 +799,7 @@
       "preferences": "Einstellungen",
       "notifications": "Benachrichtigungen",
       "tax_types": "Steuersätze",
+      "item_category": "Artikelkategorien",
       "expense_category": "Ausgabenkategorien",
       "update_app": "Applikation aktualisieren",
       "backup": "Sicherung",
@@ -1153,6 +1154,10 @@
       "payments_attached": "This payment method is already attached to payments. Please delete the attached payments to proceed with deletion.",
       "expenses_attached": "This payment method is already attached to expenses. Please delete the attached expenses to proceed with deletion.",
       "deleted_message": "Zahlungsart erfolgreich gelöscht"
+    },
+    "item_category": {
+      "title": "Artikelkategorien",
+      "description": "Artikel können Kategorien haben. Sie können diese Kategorien nach Belieben hinzufügen oder entfernen.\n"
     },
     "expense_category": {
       "title": "Ausgabenkategorien",

--- a/resources/scripts/locales/en.json
+++ b/resources/scripts/locales/en.json
@@ -1161,7 +1161,8 @@
       "category_name": "Name",
       "category_number": "Number",
       "add_new_category": "Add new Category",
-      "add_category": "Add Category"
+      "add_category": "Add Category",
+      "updated_message": "Category updated"
     },
     "expense_category": {
       "title": "Expense Categories",

--- a/resources/scripts/locales/en.json
+++ b/resources/scripts/locales/en.json
@@ -799,6 +799,7 @@
       "preferences": "Preferences",
       "notifications": "Notifications",
       "tax_types": "Tax Types",
+      "item_category": "Article Categories",
       "expense_category": "Expense Categories",
       "update_app": "Update App",
       "backup": "Backup",
@@ -1153,6 +1154,14 @@
       "payments_attached": "This payment method is already attached to payments. Please delete the attached payments to proceed with deletion.",
       "expenses_attached": "This payment method is already attached to expenses. Please delete the attached expenses to proceed with deletion.",
       "deleted_message": "Payment Mode deleted successfully"
+    },
+    "item_category": {
+      "title": "Article categories",
+      "description": "Articles can have categories. You can add or remove these categories as you wish.\n",
+      "category_name": "Name",
+      "category_number": "Number",
+      "add_new_category": "Add new Category",
+      "add_category": "Add Category"
     },
     "expense_category": {
       "title": "Expense Categories",

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,6 +46,7 @@ use Crater\Http\Controllers\V1\Admin\Invoice\InvoiceTemplatesController;
 use Crater\Http\Controllers\V1\Admin\Invoice\SendInvoiceController;
 use Crater\Http\Controllers\V1\Admin\Invoice\SendInvoicePreviewController;
 use Crater\Http\Controllers\V1\Admin\Item\ItemsController;
+use Crater\Http\Controllers\V1\Admin\Item\ItemCategoriesController;
 use Crater\Http\Controllers\V1\Admin\Item\UnitsController;
 use Crater\Http\Controllers\V1\Admin\Mobile\AuthController;
 use Crater\Http\Controllers\V1\Admin\Modules\ApiTokenController;
@@ -257,9 +258,12 @@ Route::prefix('/v1')->group(function () {
 
             Route::post('/items/delete', [ItemsController::class, 'delete']);
 
+            Route::apiResource('items/categories', ItemCategoriesController::class);
+
             Route::resource('items', ItemsController::class);
 
             Route::resource('units', UnitsController::class);
+
 
 
             // Invoices

--- a/tests/Feature/Admin/ItemCategoryTest.php
+++ b/tests/Feature/Admin/ItemCategoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Crater\Http\Controllers\V1\Admin\Item\ItemCategoriesController;
+use Crater\Http\Requests\ItemCategoryRequest;
+use Crater\Models\ItemCategory;
+use Crater\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Sanctum\Sanctum;
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+beforeEach(function () {
+    Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
+    Artisan::call('db:seed', ['--class' => 'DemoSeeder', '--force' => true]);
+
+    $user = User::find(1);
+    $this->withHeaders([
+        'company' => $user->companies()->first()->id,
+    ]);
+    Sanctum::actingAs(
+        $user,
+        ['*']
+    );
+});
+
+test('get item categories', function () {
+    $response = getJson('api/v1/items/categories');
+
+    $response->assertOk();
+});
+
+test('create category', function () {
+    $category = ItemCategory::factory()->raw();
+
+
+    $response = postJson('api/v1/items/categories', $category);
+
+    $response->assertStatus(201);
+
+    $this->assertDatabaseHas('item_categories', [
+        'name' => $category['name'],
+        'number' => $category['number'],
+    ]);
+});
+
+test('store validates using a form request', function () {
+    $this->assertActionUsesFormRequest(
+        ItemCategoriesController::class,
+        'store',
+        ItemCategoryRequest::class
+    );
+});
+
+test('get category', function () {
+    $category = ItemCategory::factory()->create();
+
+    getJson("api/v1/items/categories/{$category->id}")->assertOk();
+});
+
+test('update category', function () {
+    $category = ItemCategory::factory()->create();
+
+    $category2 = ItemCategory::factory()->raw();
+
+    putJson('api/v1/items/categories/'.$category->id, $category2)->assertOk();
+
+    $this->assertDatabaseHas('item_categories', [
+        'id' => $category->id,
+        'name' => $category2['name'],
+        'number' => $category2['number'],
+    ]);
+});
+
+test('update validates using a form request', function () {
+    $this->assertActionUsesFormRequest(
+        ItemCategoriesController::class,
+        'update',
+        ItemCategoryRequest::class
+    );
+});
+
+test('delete category', function () {
+    $category = ItemCategory::factory()->create();
+
+    deleteJson('api/v1/items/categories/'.$category->id)
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+        ]);
+
+    $this->assertDeleted($category);
+});

--- a/tests/Unit/ItemCategoryTest.php
+++ b/tests/Unit/ItemCategoryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Crater\Models\ExpenseCategory;
+use Crater\Models\ItemCategory;
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
+    Artisan::call('db:seed', ['--class' => 'DemoSeeder', '--force' => true]);
+});
+
+test('item category has many items', function () {
+    $category = ItemCategory::factory()->hasItems(5)->create();
+
+    $this->assertCount(5, $category->items);
+    $this->assertTrue($category->items()->exists());
+});


### PR DESCRIPTION
This PR adds the ability to create categories for Items. Please note: This PR is work in progress!

Features:

- [x] Add backend code for item categories
- [ ] Add backend code for connecting categories to items
- [x] Add frontend code for managing item categories
- [ ] Add frontend code to connect categories to items
- [ ] Add overwrite options for categories on estimates and invoices
- [ ] Add output in PDF

A category consists of a name and an number (=> 23 - Household).

To test the existing code by hand:
- Open Settings -> Article Categories
- You can now index, view, add, update and delete categories