### PR TITLE
Patch setup.sh script to deploy without plugins error.

### DIFF
--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+docker compose exec app composer config --no-plugins allow-plugins.pestphp/pest-plugin true
 docker-compose exec app composer install --no-interaction --prefer-dist --optimize-autoloader
 
 docker-compose exec app php artisan storage:link || true


### PR DESCRIPTION
Running ./docker-compose/setup.sh throws an error with allow-plugins:
```
In PluginManager.php line 744:
                                                                                                                                                                              
  pestphp/pest-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.                           
  You can run "composer config --no-plugins allow-plugins.pestphp/pest-plugin [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)  
  See https://getcomposer.org/allow-plugins 
```

Added `docker compose exec app composer config --no-plugins allow-plugins.pestphp/pest-plugin true` to setup script.

Resolves the following duplicate issues:
fixes #1006
fixes  #1015