### PR TITLE
Moved setup script patch to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,10 @@
   "config": {
     "optimize-autoloader": true,
     "preferred-install": "dist",
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
   },
   "extra": {
     "laravel": {

--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-docker compose exec app composer config --no-plugins allow-plugins.pestphp/pest-plugin true
 docker-compose exec app composer install --no-interaction --prefer-dist --optimize-autoloader
 
 docker-compose exec app php artisan storage:link || true

--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+docker compose exec app composer config --no-plugins allow-plugins.pestphp/pest-plugin true
 docker-compose exec app composer install --no-interaction --prefer-dist --optimize-autoloader
 
 docker-compose exec app php artisan storage:link || true


### PR DESCRIPTION
On second glance regarding: [38c4b9e](https://github.com/crater-invoice/crater/commit/38c4b9ebced6d75d7fd4f4e7a1ae45f6a5604fd8)

The config should be directly inside composer.json and not setup.sh. I've removed the composer config line from the setup.sh script and edited composer.json to have the plugin allowed. It really shouldn't be in the setup script at all.

```json
  "config": {
    "optimize-autoloader": true,
    "preferred-install": "dist",
    "sort-packages": true,
    "allow-plugins": {
      "pestphp/pest-plugin": true
    }
  },
```