### PR TITLE
Adding object-fit rules so thumbnail image does not appear stretched.

### DIFF
--- a/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
+++ b/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
@@ -143,7 +143,7 @@
           <template #activator>
             <img
               :src="previewAvatar"
-              class="block w-8 h-8 rounded md:h-9 md:w-9"
+              class="block w-8 h-8 rounded md:h-9 md:w-9 object-cover"
             />
           </template>
 


### PR DESCRIPTION
#### Current
Avatar thumbnail was stretched on the header.
![image](https://user-images.githubusercontent.com/16215807/195071085-f9775c6a-aafd-4e83-8a3a-bfd75ad69f76.png)

#### New
I've just added `object-cover` rules so that the image is not distorted.
![image](https://user-images.githubusercontent.com/16215807/195071332-f967b6e5-a897-41fb-9209-6ed21c03fcb2.png)

