### PR TITLE
Update php version to 8.1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.1-fpm
 
 # Arguments defined in docker-compose.yml
 ARG user


### PR DESCRIPTION
Version 7.4 no longer works when running docker-compose/setup.sh. Updated to 8.1 in Dockerfile. Issue is now resolved and Crater sets up as expected without version conflicts.