### PR TITLE
feat: front-end files bulding

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2        
       - name: Generate UUID image name
         id: uuid
         run: echo "UUID_TAG_APP=$(uuidgen)" >> $GITHUB_ENV
@@ -33,11 +31,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ./uffizzi/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
 
   build-nginx:
+    needs: 
+      - build-application
     name: Build and Push `nginx`
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
@@ -65,6 +62,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ./uffizzi/nginx/Dockerfile
+          build-args: |
+            BASE_IMAGE=${{ needs.build-application.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/uffizzi/Dockerfile
+++ b/uffizzi/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
     unzip \
     libzip-dev \
     libmagickwand-dev \
-    mariadb-client
+    mariadb-client \
+    npm
 
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -44,5 +45,20 @@ RUN chmod -R 775 composer.json composer.lock \
         storage/logs/ bootstrap/cache/ /home/crater-user/.composer
 RUN chown -R $(whoami):$(whoami) /var/log/
 RUN chmod -R 775 /var/log
+
+# Cleanup manually generated build files
+RUN rm -rf /var/www/public/build
+RUN npm config set user 0
+RUN npm config set unsafe-perm true
+# Frontend bulding
+RUN sed -i 's/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/g' /var/www/.env
+RUN sed -i 's/DB_DATABASE=crater/DB_DATABASE=\/tmp\/crater.sqlite/g' /var/www/.env
+RUN touch /tmp/crater.sqlite
+RUN composer install --no-interaction --prefer-dist
+RUN npm i -f
+RUN npm install --save-dev sass
+RUN export NODE_OPTIONS="--max-old-space-size=4096" && /usr/bin/npx vite build --target=es2020
+RUN sed -i 's/DB_CONNECTION=sqlite/DB_CONNECTION=mysql/g' /var/www/.env
+RUN sed -i 's/DB_DATABASE=\/tmp\/crater.sqlite/DB_DATABASE=crater/g' /var/www/.env
 
 USER crater-user

--- a/uffizzi/nginx/Dockerfile
+++ b/uffizzi/nginx/Dockerfile
@@ -1,7 +1,9 @@
+ARG BASE_IMAGE
+
+FROM $BASE_IMAGE as build
 FROM nginx:1.17-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
 
-COPY ./ /var/www
+COPY --from=build /var/www /var/www
 COPY ./uffizzi/nginx/nginx /etc/nginx/conf.d/
-


### PR DESCRIPTION
This PR solves the problem with front-end files compiling —  in the preview deployment.
During the building process it cleans up `/var/www/public/build` folder, and after that it builds the front end on the same path.

The preview is deployed [here](https://app.uffizzi.com//github.com/daramayis/f-crater/pull/4).
Issue: https://github.com/crater-invoice/crater/issues/1097