### PR TITLE
bump to latest nginx alpine image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - crater
 
   nginx:
-    image: nginx:1.17-alpine
+    image: nginx:alpine
     restart: unless-stopped
     ports:
       - 80:80


### PR DESCRIPTION
I updated the used nginx tag to nginx:alpine because the current tag is using a three year old image:
![image](https://user-images.githubusercontent.com/11352551/205720466-eb40c731-52cc-4b2e-ad2f-6aa3ca47ffa3.png)