### PR TITLE
fix: base_due_amount correction on payment delete

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -246,7 +246,7 @@ class Payment extends Model implements HasMedia
             if ($payment->invoice_id != null) {
                 $invoice = Invoice::find($payment->invoice_id);
                 $invoice->due_amount = ((int)$invoice->due_amount + (int)$payment->amount);
-
+                $invoice->base_due_amount = $invoice->due_amount;
                 if ($invoice->due_amount == $invoice->total) {
                     $invoice->paid_status = Invoice::STATUS_UNPAID;
                 } else {


### PR DESCRIPTION
Hi,

If the the payment against any invoice is deleted, both columns `due_amount` and `base_due_amount` should revert back because the base_due_amount is being used in dashboard aggregates.

https://github.com/crater-invoice/crater/blob/393fe20010d4ddbc4eb49e739000f55d8d7e0b8b/app/Http/Controllers/V1/Admin/Dashboard/DashboardController.php#L138-L139