### PR TITLE
Adds Zip to the required PHP Extension check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Homestead.yaml
 /public/docs
 /.scribe
 !storage/fonts/.gitkeep
+.DS_Store

--- a/config/installer.php
+++ b/config/installer.php
@@ -27,6 +27,7 @@ return [
             'tokenizer',
             'JSON',
             'cURL',
+            'zip',
         ],
         'apache' => [
             'mod_rewrite',


### PR DESCRIPTION
ZIP is listed as a requirement for install but it's not checked for when installing or upgrading.
 
![image](https://user-images.githubusercontent.com/31537/219922446-27ade81f-d67a-46f5-b992-1b5f5d7349de.png)
