### PR TITLE
Remove IdeHelperServiceProvider from providers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -169,7 +169,6 @@ return [
         Crater\Providers\RouteServiceProvider::class,
         Crater\Providers\DropboxServiceProvider::class,
         Crater\Providers\ViewServiceProvider::class,
-        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
     ],
 
     /*


### PR DESCRIPTION
This is to prevent production build to fail when using:
```bash
composer install --optimize-autoloader --no-dev
...
In ProviderRepository.php line 208:
  Class "Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" not found
```

As I understand IDE Helper Generator for Laravel [documentation](https://github.com/barryvdh/laravel-ide-helper#installation), you should no force the provider in the config since it is auto discovered:
> This package makes use of [Laravels package auto-discovery mechanism](https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518), which means if you don't install dev dependencies in production, it also won't be loaded.