### PR TITLE
Allow <p> tags in string formatting

### DIFF
--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -175,10 +175,6 @@ trait GeneratesPdfTrait
 
         $str = preg_replace("/<[^\/>]*>([\s]?)*<\/[^>]*>/", '', $str);
 
-        $str = str_replace("<p>", "", $str);
-
-        $str = str_replace("</p>", "</br>", $str);
-
         return $str;
     }
 }


### PR DESCRIPTION
Hello,

I would like to suggest to keep `<p>` tags when formatting strings.
I ran into an issue where I was not able to format my text as I would like and I found that this was the cause of my issue.

I think this should be the users responsibility to format his text properly using paragraphs (or not).

If you dont want to create a new paragraph, you can create a new line with `Shift + Enter` => `<br>` is created instead of `<p>`.
This is how all rich text inputs work (even Microsoft Word).
(I checked and crater rich text component also works like this)