### PR TITLE
Create official crater docker images

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -65,6 +65,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: guanana/crater
+          readme-filepath: ./readme.md
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
@@ -120,6 +128,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: guanana/crater
+          readme-filepath: ./readme.md
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: guanana/crater
+          repository: guanana2/crater
           readme-filepath: ./readme.md
 
       - name: Build and push
@@ -134,7 +134,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: guanana/crater
+          repository: guanana2/crater-crond
           readme-filepath: ./readme.md
 
       - name: Build and push

--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -1,0 +1,135 @@
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+          php: [ '7.4', '8.0' ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check coding style
+        run: ./vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no --config=.php-cs-fixer.dist.php
+
+      - name: Unit Tests
+        run: php ./vendor/bin/pest
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  build-php:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Support for more platforms
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: |
+            ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ github.event.repository.name }}
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=schedule
+            type=edge,enable=true,priority=700,prefix=,suffix=,branch=$repo.default_branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64, linux/386, linux/arm/v7, linux/arm/v6
+          build-args: |
+            user=crater-user
+            uid=1000
+            CRATER_DOCKER_TAG=${{ steps.meta.outputs.version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-crond:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Support for more platforms
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: |
+            ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ github.event.repository.name }}-crond
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-crond
+          tags: |
+            type=schedule
+            type=edge,enable=true,priority=700,prefix=,suffix=,branch=$repo.default_branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker-compose/cron.dockerfile
+          platforms: linux/amd64, linux/arm64, linux/386, linux/arm/v7, linux/arm/v6
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG uid
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
+    wget \
     curl \
     libpng-dev \
     libonig-dev \
@@ -32,9 +33,15 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 # Create system user to run Composer and Artisan Commands
 RUN useradd -G www-data,root -u $uid -d /home/$user $user
 RUN mkdir -p /home/$user/.composer && \
-    chown -R $user:$user /home/$user
+    chown -R $user:$user /home/$user /var/www/ && \
+    chmod -R 775 /var/www/
 
 # Set working directory
 WORKDIR /var/www
+RUN echo "${CRATER_DOCKER_TAG}" > /crater.docker.tag
+COPY --chmod=0755 docker-compose/entrypoint.sh /usr/local/
+
+CMD ["php-fpm"]
+ENTRYPOINT ["/usr/local/entrypoint.sh"]
 
 USER $user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,63 +1,74 @@
-version: '3'
+version: '3.3'
 
 services:
   app:
-    build:
-      args:
-        user: crater-user
-        uid: 1000
-      context: ./
-      dockerfile: Dockerfile
-    image: crater-php
-    restart: unless-stopped
-    working_dir: /var/www/
+    image: guanana2/crater:latest
+    working_dir: /var/www
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/9000'"
+      interval: 10s
+      timeout: 10s
+      retries: 20
     volumes:
-      - ./:/var/www
-      - ./docker-compose/php/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini:rw,delegated
-    networks:
-      - crater
-
+      - crater_data:/var/www/
+      - ./.env:/var/www/.env
   db:
-    image: mariadb
-    restart: always
+    image: mariadb:10.9.6
     volumes:
       - db:/var/lib/mysql
       # If you want to persist data on the host, comment the line above this one...
       # and uncomment the line under this one.
       #- ./docker-compose/db/data:/var/lib/mysql:rw,delegated
     environment:
-      MYSQL_USER: crater
-      MYSQL_PASSWORD: crater
-      MYSQL_DATABASE: crater
-      MYSQL_ROOT_PASSWORD: crater
+      MYSQL_USER: crater_dev
+      MYSQL_PASSWORD: crater_dev
+      MYSQL_DATABASE: crater_dev
+      MYSQL_ROOT_PASSWORD: crater_dev_root
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
     ports:
       - '33006:3306'
-    networks:
-      - crater
 
   nginx:
-    image: nginx:1.17-alpine
-    restart: unless-stopped
+    image: nginx:1.25.0-alpine-slim
+    volumes:
+      #- SSL:/etc/nginx/ssl/
+      - crater_data:/var/www
+      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
     ports:
-      - 80:80
-    volumes:
-      - ./:/var/www
-      - ./docker-compose/nginx:/etc/nginx/conf.d/
-    networks:
-      - crater
-
+      - '443:443'
+    depends_on:
+      db:
+        condition: service_healthy
+      app:
+        condition: service_healthy
   cron:
-    build:
-      context: ./
-      dockerfile: ./docker-compose/cron.dockerfile
+    image: guanana2/crater-crond:latest
+    depends_on:
+      db:
+        condition: service_healthy
+      app:
+        condition: service_healthy
     volumes:
-      - ./:/var/www
-    networks:
-      - crater
+      - crater_data:/var/www
 
 volumes:
   db:
+  crater_data:
 
-networks:
-  crater:
-    driver: bridge
+# NFS Example
+#  db:
+#    driver_opts:
+#      type: "nfs"
+#      o: "addr=nfserver,nolock,soft,rw,sec=sys,vers=4.2"
+#      device: ":/crater_dev/data/db"
+#  crater_data:
+#    driver_opts:
+#      type: "nfs"
+#      o: "addr=nfserver,nolock,soft,rw,sec=sys,vers=4.2"
+#      device: ":/crater_dev/data/www"

--- a/docker-compose.yml.swarm
+++ b/docker-compose.yml.swarm
@@ -1,0 +1,101 @@
+version: '3.3'
+
+services:
+  app:
+    image: guanana2/crater:latest
+    working_dir: /var/www
+    environment:
+      APP_ENV: production
+      APP_KEY: "base64:UGvXz/q5EwNVNVHBnDnEgaD0JFxlVnM0iha4KNexample:"
+      APP_DEBUG: "true"
+      APP_LOG_LEVEL: debug
+      APP_URL: "https://crater.example.com"
+      DB_CONNECTION: mysql
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_DATABASE: crater_db
+      DB_USERNAME: crater_username
+      DB_PASSWORD: crater_pass
+      BROADCAST_DRIVER: log
+      CACHE_DRIVER: file
+      QUEUE_DRIVER: sync
+      SESSION_DRIVER: cookie
+      SESSION_LIFETIME: 1440
+      REDIS_HOST: 127.0.0.1
+      REDIS_PASSWORD: null
+      REDIS_PORT: 6379
+      MAIL_DRIVER: mail
+      MAIL_FROM_ADDRESS: crater@example.com
+      MAIL_FROM_NAME: "Crater Test"
+      SANCTUM_STATEFUL_DOMAINS: crater.example.com
+      SESSION_DOMAIN: crater.example.com
+      TRUSTED_PROXIES: "*"
+      CRON_JOB_AUTH_TOKEN: ""
+    user: "1000"
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/9000'"
+      interval: 10s
+      timeout: 10s
+      retries: 20
+    depends_on:
+      - db
+    volumes:
+      - crater_data:/var/www
+  db:
+    image: mariadb:10.9.6
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      MYSQL_USER: crater_username
+      MYSQL_PASSWORD: crater_pass
+      MYSQL_DATABASE: crater_db
+      MYSQL_ROOT_PASSWORD: crater_dev_root
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+    ports:
+      - '33006:3306'
+
+  nginx:
+    image: nginx:1.25.0-alpine-slim
+    volumes:
+      - SSL:/etc/nginx/ssl/
+      - crater_data:/var/www
+    ports:
+      - '443:443'
+    depends_on:
+      - db
+      - app
+    configs:
+      - source: crater_nginx.conf
+        target: /etc/nginx/conf.d/nginx.conf
+
+
+  cron:
+    image: guanana2/crater-crond:latest
+    depends_on:
+      - db
+      - app
+    volumes:
+      - crater_data:/var/www
+
+volumes:
+  db:
+    driver_opts:
+      type: "nfs"
+      o: "addr=nfserver.example,nolock,soft,rw,sec=sys,rsize=131072,wsize=131072,vers=4.0"
+      device: ":/Swarm/crater_dev/data/db"
+  crater_data:
+    driver_opts:
+      type: "nfs"
+      o: "addr=nfserver.example,nolock,soft,rw,rsize=131072,wsize=131072,sec=sys,vers=4.0"
+      device: ":/Swarm/crater_dev/data/www"
+  SSL:
+    external: true
+
+configs:
+  crater_nginx.conf:
+    external: true
+  crater_uploads.ini:
+    external: true

--- a/docker-compose/entrypoint.sh
+++ b/docker-compose/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+DOCKER_TAG=`cat /crater.docker.tag`
+DIR="/var/www"
+TMPDIR="/var/www/tmp"
+REPO_URL=https://github.com/crater-invoice/crater.git
+TAG=${DOCKER_TAG:-master}
+
+if [ -d "${DIR}/app" ]
+then
+    echo "Starting application"
+else
+    if [[ $(stat -c %u $DIR) == 1000 ]]; then
+        echo "Cloning app. Configuring $APP_URL for the first time..."
+        git clone -q --depth 1 --branch $TAG $REPO_URL $TMPDIR
+        cp -Rp $TMPDIR/* $DIR/
+        rm -rf $TMPDIR
+        # Ensure .env is present
+        touch $DIR/.env
+        echo "Installing requirements..."
+        composer -q install
+        chmod 775 storage/framework/ storage/logs/ bootstrap/cache/
+    else
+        echo "Make sure the root directory ${DIR} is owned by `whoami`"
+        exit 1
+    fi
+fi
+
+exec "$@"

--- a/docker-compose/nginx/nginx.conf.ssl
+++ b/docker-compose/nginx/nginx.conf.ssl
@@ -1,0 +1,26 @@
+server {
+    client_max_body_size 64M;
+    listen 443 ssl;
+    ssl_certificate     ssl/cert.pem;
+    ssl_certificate_key ssl/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/public;
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_read_timeout 300;
+    }
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}


### PR DESCRIPTION
Add some examples for docker-compose and docker swarm and create all the config needed to allow docker images to be used directly (instead of the current only option that is to build).

This will allow as well easier portability and automation.

Closes #1242