### PR TITLE
Removed IdeHelperServiceProvider from providers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -169,7 +169,6 @@ return [
         Crater\Providers\RouteServiceProvider::class,
         Crater\Providers\DropboxServiceProvider::class,
         Crater\Providers\ViewServiceProvider::class,
-        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
     ],
 
     /*


### PR DESCRIPTION
Removed the registration for the `IdeHelperServiceProvider` provider to leverage Laravel's package auto-discovery.

The package will be auto-discovered and installed when the `composer install` command is executed and will be omitted when `composer install --no-dev` command is executed.

Fixes #1137 